### PR TITLE
Feature/remove galois in pre type one two primes

### DIFF
--- a/isogeny_primes.py
+++ b/isogeny_primes.py
@@ -32,7 +32,7 @@ import json
 from pathlib import Path
 from itertools import product
 import logging
-from sage.all import (QQ, QQbar, next_prime, IntegerRing, prime_range, ZZ, pari,
+from sage.all import (QQ, next_prime, IntegerRing, prime_range, ZZ, pari,
         PolynomialRing, Integer, Rationals, legendre_symbol, QuadraticField,
         log, exp, find_root, ceil, NumberField, hilbert_class_polynomial,
         RR, EllipticCurve, ModularSymbols, Gamma0, lcm, oo, parent, Matrix,

--- a/isogeny_primes.py
+++ b/isogeny_primes.py
@@ -993,7 +993,7 @@ def get_pre_type_one_two_primes(K, norm_bound=50, loop_curves=False, use_PIL=Fal
 
     if use_PIL and h_K > 1:
         logging.debug("Using PIL")
-        PIL_integers_dict = get_PIL_integers(aux_primes)
+        PIL_integers_dict = get_PIL_integers(aux_primes, frob_polys_dict, Kgal, epsilons, embeddings)
         for eps in epsilons:
             tracking_dict_inv_collapsed[eps] = gcd(tracking_dict_inv_collapsed[eps], PIL_integers_dict[eps])
 

--- a/sandbox.py
+++ b/sandbox.py
@@ -222,3 +222,18 @@ aux_primes = list(beta_data.keys())
 x = polygen(QQ);  K.<a> = NumberField(x^3 + 14*x - 1)
 aux_primes = K.primes_of_bounded_norm(30)
 CK = K.class_group()
+
+
+R.<x> = QQ[]
+f1 = x^3 - 17
+f2 = x^4 - 18
+f3 = x^5 + 19
+
+K1 = NumberField(f1,'a')
+K2 = NumberField(f2,'b')
+K3 = NumberField(f3,'c')
+
+my_list = [K1,K2,K3]
+
+the_shtuff = [chr(i+97) for i,F in enumerate(frob_polys_dict[q])]
+# the_nfs = [NumberField(F, chr(i+97)) for i,F in enumerate(frob_polys_dict[q])]

--- a/sandbox.py
+++ b/sandbox.py
@@ -212,3 +212,13 @@ for q in K_primes_deg_1_princ:
     vals_set = set(vals)
     if (0 in vals_set) or (len(vals_set) > 1):
         print(q)
+
+import pickle
+with open('beta_data.pickle', 'rb') as handle:
+    beta_data = pickle.load(handle)
+
+aux_primes = list(beta_data.keys())
+
+x = polygen(QQ);  K.<a> = NumberField(x^3 + 14*x - 1)
+aux_primes = K.primes_of_bounded_norm(30)
+CK = K.class_group()


### PR DESCRIPTION
This PR has implemented all the changes we have recently discussed via call/email; they are all contained in the `PreTypeOneTwoPrimes` part of the code:

1. The field `K` is no longer required to be Galois. The computation proceeds via the embeddings of `K` into its galois closure `Kgal`.
2. The emergency aux primes have been corrected. To keep these to an absolute minimum for now (for testing), the emergency aux primes corresponding to generators of the class group have only been added in the case where `K` contains an imaginary quadratic field. (I eventually want to do this more generally, but for testing the `use_PIL` code to be described below, it is better to not add potentially large primes if not strictly necessary.)
3. The epsilons are now computed with respect to `K` and not `Kgal`. However, if `K` is itself Galois, then we still do the "mod out by galois action" idea on the epsilons.
4. The divisibilities from units is computed as a first step (see line 898 in `isogeny_primes.py`).
5. The `filter_ABC_primes` method is now fixed, using the observation that if the epsilon has different integers in it, then `p` cannot be inert.
6. Most significantly, the "Lambda" idea has been implemented. This all takes place in the block of code after `if use_PIL and h_K > 1:` on line 927 (this idea doesn't bring us anything if the class group is trivial). `use_PIL` is now a flag the user can request at the command line.

Let me say a few things about how (6) works. Firstly, when computing the `C` integers, the frobenius polynomials used for each auxiliary prime are stored in a dictionary `frob_polys_dict`, which is then used in the `use_PIL` code. The first step of this new code extracts the roots of those frobenius polynomials and creates essentially the set you defined in Definition 4.7 of the overleaf (expect that I've raised everything to the 12 at this point). It would help if we didn't need to keep track of the field in which all of these values are contained in, and I tried using coercions into `QQbar` but that didn't work, so the `beta_data` dict keeps track of the field in which all of the betas are defined as well as the betas themselves; so the dict is the tuple `(the_split_field, the_betas)`.

After this, the basis of Lambda is computed, using the code you supplied on CoCalc. Since we've already by this point computed the diagonal entries of this basis, we only care about doing computations on basis elements which are not diagonal; this is the list `good_basis_elements`.

We then want to compute, for each good basis element, the cartesian product of the different beta sets required, as well as the alpha corresponding to this basis element. this is eventually done in the `pre_eps_data_blob`. This requires one to compute the compositum `big_compositum` of some of the `the_split_field` number fields computed in the `beta_data` dict. This is done in the method `get_compositum`. Eventually, `pre_eps_data_blob` returns the alpha, all the products of the betas, as well as maps from `Kgal` and `big_compositum` into the compositum of `big_compositum` with `Kgal`, referred to as `huge` in the naming of those maps.

Having made these data blobs, we are then able to compute the norm in Proposition 4.8 for each epsilon and basis element. Running lcms and gcds are set-up to compute the integers and gcd them with what we got from before; this happens on line 971.

The problem with all of this is that it doesn't currently work, hence this being only a draft PR. It seems to get stuck in computing these big compositum fields, which goes back to the `get_compositum` function on line 665. This seems to be a bottleneck to this approach.

## Do you know  a better way to do this? 

Or even a way to not have to keep track of the fields where these products of betas are living? As I wrote above I did hope there would be a lazy way of doing this with `QQbar`, but I couldn't get that to work.

For the record I was running this code from the command line: `sage isogeny_primes.py 'x^3 - x^2 + 5*x + 1' --norm_bound 10 --verbose --use_PIL`