### PR TITLE
Implement TypeTwoNotMomosePrimes. Add PARI/GP code for checking type 2 primes

### DIFF
--- a/gp_scripts/partype2primesuniform.gp
+++ b/gp_scripts/partype2primesuniform.gp
@@ -35,8 +35,6 @@
 
 */
 
-\\ 80 billion is the bound for all |D| <= 10
-
 \\check if condition CC is satisfied
 satisfiesCCunif(p) =
 {

--- a/isogeny_primes.py
+++ b/isogeny_primes.py
@@ -93,7 +93,7 @@ def get_isogeny_primes(
 
     # Get and show PreTypeOneTwoPrimes
 
-    pre_type_one_two_primes = get_pre_type_one_two_primes(
+    embeddings, pre_type_one_two_primes = get_pre_type_one_two_primes(
         K,
         norm_bound=norm_bound,
         loop_curves=loop_curves,
@@ -115,7 +115,7 @@ def get_isogeny_primes(
 
     # Get and show TypeTwoPrimes
 
-    type_2_primes = get_type_2_primes(K, bound=bound)
+    type_2_primes = get_type_2_primes(K, embeddings, bound=bound)
     logging.info("type_2_primes = {}".format(type_2_primes))
 
     # Put them all together

--- a/sage_code/common_utils.py
+++ b/sage_code/common_utils.py
@@ -31,12 +31,14 @@ from sage.combinat.permutation import Permutation
 from sage.groups.additive_abelian.additive_abelian_group import AdditiveAbelianGroup
 from sage.groups.perm_gps.permgroup import PermutationGroup
 from sage.groups.perm_gps.permgroup_named import TransitiveGroup, SymmetricGroup
+import functools
 
 R = PolynomialRing(Rationals(), "x")
 x = R.gen()
 EC_Q_ISOGENY_PRIMES = {2, 3, 5, 7, 11, 13, 17, 19, 37, 43, 67, 163}
 CLASS_NUMBER_ONE_DISCS = {-3, -4, -7, -8, -11, -19, -43, -67, -163}
 SMALL_GONALITIES = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 47, 59, 71}
+
 # Global methods
 
 
@@ -74,6 +76,12 @@ def get_weil_polys(F):
     a = F.degree()
     weil_polys = R.weil_polynomials(2, q ** a)
     return [f for f in weil_polys if weil_polynomial_is_elliptic(f, q, a)]
+
+
+@functools.cache
+def get_ordinary_weil_polys_from_values(q, a):
+    weil_polys = R.weil_polynomials(2, q ** a)
+    return [f for f in weil_polys if f[1] % q != 0]
 
 
 def eps_exp(alpha, eps, Sigma):

--- a/sage_code/pre_type_one_two.py
+++ b/sage_code/pre_type_one_two.py
@@ -521,7 +521,7 @@ def get_pre_type_one_two_primes(
             embeddings,
             stop_strategy=stop_strategy,
         )
-        return output
+        return embeddings, output
 
     # Split according to epsilon type, get prime divisors, and filter
 
@@ -540,4 +540,4 @@ def get_pre_type_one_two_primes(
     # Take union of all primes over all epsilons, sort, and return
 
     output = set.union(*(val for val in final_split_dict.values()))
-    return sorted(output)
+    return embeddings, sorted(output)


### PR DESCRIPTION
This PR does two things. 

1. Implements TypeTwoNotMomosePrimes.
2. Makes the PARI/GP code for checking Momose Type 2 primes more general. (previously it was still only implemented for quadratic fields.)