### PR TITLE
Uniform bounds v0.1

### DIFF
--- a/sage_code/__init__.py
+++ b/sage_code/__init__.py
@@ -27,18 +27,18 @@ Make sure we show a decent error if a to old version of sage is being used
 
 """
 
-try:
-    from sagemath.check_version import check_version
+# try:
+#     from sagemath.check_version import check_version
 
-    check_version(">=9.4")
-except ModuleNotFoundError as err:
-    raise RuntimeError(
-        """
-        Not all requirements of Isogeny Primes are installed. Please do
-            sage -pip install -r requirements.txt
-        Before continuing.
-        """
-    ) from ModuleNotFoundError
+#     check_version(">=9.4")
+# except ModuleNotFoundError as err:
+#     raise RuntimeError(
+#         """
+#         Not all requirements of Isogeny Primes are installed. Please do
+#             sage -pip install -r requirements.txt
+#         Before continuing.
+#         """
+#     ) from ModuleNotFoundError
 
 from .monkey_patch_sage import monkey_patch
 

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -31,7 +31,7 @@
 from sage.all import Partitions, divisors, matrix, GF, lcm, gcd, prime_range, prod, Integer
 from itertools import product
 import logging
-from .common_utils import get_weil_polys, R, x
+from .common_utils import get_weil_polys, x
 from .pil_integers import collapse_tuple
 from .type_one_primes import cached_bad_formal_immersion_data
 
@@ -142,14 +142,8 @@ def B_eps_q(d,eps,q, known_mult_bound=0):
         B = gcd(known_mult_bound, lcm(B,pil_int))
     return B_star, B
 
+def core_loop(d, eps, aux_primes):
 
-def tr_not_6_unif_bd(d, eps, q_bd=2):
-
-    assert q_bd > 1
-    aux_primes = prime_range(q_bd+1)
-
-    logger.debug(f"Aux primes for (a) are {aux_primes}")
-    
     mult_upper_bd = 0
 
     for q in aux_primes:
@@ -158,6 +152,20 @@ def tr_not_6_unif_bd(d, eps, q_bd=2):
         mult_upper_bd = gcd(mult_upper_bd, B_star)
 
     return mult_upper_bd
+
+
+def unif_bd(d, eps):
+
+    tr_eps = sum(eps)
+
+    if tr_eps % 6 != 0:
+        aux_primes = prime_range(6)
+    elif tr_eps % 12 == 6:
+        aux_primes = prime_range(5, 15)
+    else:
+        raise ValueError("can't deal with this case")
+
+    return core_loop(d, eps, aux_primes)
 
 
 def type_one_unif_primes(d, q_bd=4):
@@ -182,3 +190,4 @@ def type_one_unif_primes(d, q_bd=4):
     output = set(Integer(mult_upper_bd).prime_divisors())
     output = output.union(set(bad_formal_immersion_list))
     return output
+    

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -54,11 +54,11 @@ def get_beta_mats_with_pow(F, pow=1):
     # We also need to add \pm 1, \pm q
 
     f1 = (x - 1) * (x + 1)
-    output.append(matrix.companion(f1))
+    output.append(matrix.companion(f1) ** pow)
 
     q = F.cardinality()
     fq = (x - q) * (x + q)
-    output.append(matrix.companion(fq))
+    output.append(matrix.companion(fq) ** pow)
 
     return output
 
@@ -105,7 +105,7 @@ def bound_from_split_type(split_type, eps, q, known_mult_bound=0):
         eps (tuple): isogeny signature
         q (int): auxiliary rational prime
     """
-    frob_poly_mats = [get_beta_mats_with_pow(GF(q**f), pow=my_e) for my_e,f in zip(split_type['es'],split_type['fs'])]
+    frob_poly_mats = [get_beta_mats_with_pow(GF(q**f), pow=12*my_e) for my_e,f in zip(split_type['es'],split_type['fs'])]
     beta_mat_tuples = list(product(*frob_poly_mats))
     collapsed_beta_mats = [
         collapse_tuple(a_beta_tuple) for a_beta_tuple in beta_mat_tuples
@@ -124,7 +124,7 @@ def bound_from_split_type(split_type, eps, q, known_mult_bound=0):
             zero_detection_flag = True
         else:
             pil_int = gcd(known_mult_bound, pil_int)
-            running_lcm = gcd(known_mult_bound, lcm(pil_int, running_lcm))
+            running_lcm = lcm(pil_int, running_lcm)
     if zero_detection_flag:
         return running_lcm, 0
     else:
@@ -183,7 +183,7 @@ def type_one_unif_primes(d, q_bd=4):
 
         agfi_q = bad_aux_prime_dict.get(str(q),1)
 
-        q_prod = prod([(q ** f - 1) for f in range(1,d+1)])
+        q_prod = lcm([(q ** f - 1) for f in range(1,d+1)])
         contribution = lcm([B_star, q_prod, agfi_q])
         mult_upper_bd = gcd(mult_upper_bd, contribution)
 

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -31,7 +31,8 @@
 from sage.all import Partitions, divisors, matrix, GF, lcm
 from itertools import product
 
-from .common_utils import get_weil_polys
+from common_utils import get_weil_polys
+from pil_integers import collapse_tuple
 
 def is_non_increasing(t):
 
@@ -39,6 +40,12 @@ def is_non_increasing(t):
         if t[j] < t[j+1]:
             return False
     return True
+
+
+def get_beta_mats_with_pow(F, pow=1):
+
+    frob_polys = get_weil_polys(F)
+    return [matrix.companion(f) ** pow for f in frob_polys]
 
 
 def remove_duplicates(list_of_e_tuples):
@@ -75,7 +82,7 @@ def splitting_types(d):
     return types
 
 
-def strong_mult_bound(d, eps, q):
+def bound_from_split_type(split_type, eps, q):
     """This implements Algorithm 5.1 from the paper, and returns the integers
        B_{eps,q} and B^*_{eps,q}.
 
@@ -84,16 +91,29 @@ def strong_mult_bound(d, eps, q):
         eps (tuple): isogeny signature
         q (int): auxiliary rational prime
     """
-
-    frob_polys = get_weil_polys(GF(q))
-    frob_poly_mats = [matrix.companion(a_frob_poly) for a_frob_poly in frob_polys]
-    matrix_parent = frob_poly_mats[0].parent()
+    frob_poly_mats = [get_beta_mats_with_pow(GF(q**f), pow=my_e) for my_e,f in zip(split_type['es'],split_type['fs'])]
+    beta_mat_tuples = list(product(*frob_poly_mats))
+    collapsed_beta_mats = [
+        collapse_tuple(a_beta_tuple) for a_beta_tuple in beta_mat_tuples
+    ]
     tr_eps = sum(eps)
-    alpha_to_eps_mat = matrix_parent(q**tr_eps)
-    B_eps_q = 1
-    for a_beta_mat in frob_poly_mats:
+    q_to_tr_eps = q**tr_eps
+    running_lcm = 1
+    for a_beta_mat in collapsed_beta_mats:
+        matrix_parent = frob_poly_mats[0].parent()
+        alpha_to_eps_mat = matrix_parent(q_to_tr_eps)
         pil_mat = alpha_to_eps_mat.tensor_product(a_beta_mat.parent()(1)) - (
                   alpha_to_eps_mat.parent()(1)).tensor_product(a_beta_mat)
         pil_int = pil_mat.det()
-        B_eps_q = lcm(pil_int, B_eps_q)
-    return B_eps_q
+        running_lcm = lcm(pil_int, running_lcm)
+    return running_lcm
+
+
+def B_eps_q(d,eps,q):
+
+    split_types = splitting_types(d)
+    B = 1
+    for split_type in split_types:
+        pil_int = bound_from_split_type(split_type, eps, q)
+        B = lcm(B,pil_int)
+    return B

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -31,8 +31,8 @@
 from sage.all import Partitions, divisors, matrix, GF, lcm
 from itertools import product
 
-from common_utils import get_weil_polys
-from pil_integers import collapse_tuple
+from .common_utils import get_weil_polys
+from .pil_integers import collapse_tuple
 
 def is_non_increasing(t):
 
@@ -100,7 +100,7 @@ def bound_from_split_type(split_type, eps, q):
     q_to_tr_eps = q**tr_eps
     running_lcm = 1
     for a_beta_mat in collapsed_beta_mats:
-        matrix_parent = frob_poly_mats[0].parent()
+        matrix_parent = a_beta_mat.parent()
         alpha_to_eps_mat = matrix_parent(q_to_tr_eps)
         pil_mat = alpha_to_eps_mat.tensor_product(a_beta_mat.parent()(1)) - (
                   alpha_to_eps_mat.parent()(1)).tensor_product(a_beta_mat)

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -145,10 +145,12 @@ def B_eps_q(d,eps,q, known_mult_bound=0):
 def core_loop(d, eps, aux_primes):
 
     mult_upper_bd = 0
+    trace_eps = sum(eps)
 
     for q in aux_primes:
         B_star, B = B_eps_q(d,eps,q,mult_upper_bd)
-        assert B_star == B
+        if trace_eps % 6 != 0:
+            assert B_star == B
         mult_upper_bd = gcd(mult_upper_bd, B_star)
 
     return mult_upper_bd

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -99,21 +99,30 @@ def bound_from_split_type(split_type, eps, q):
     tr_eps = sum(eps)
     q_to_tr_eps = q**tr_eps
     running_lcm = 1
+    zero_detection_flag = False
     for a_beta_mat in collapsed_beta_mats:
         matrix_parent = a_beta_mat.parent()
         alpha_to_eps_mat = matrix_parent(q_to_tr_eps)
         pil_mat = alpha_to_eps_mat.tensor_product(a_beta_mat.parent()(1)) - (
                   alpha_to_eps_mat.parent()(1)).tensor_product(a_beta_mat)
         pil_int = pil_mat.det()
-        running_lcm = lcm(pil_int, running_lcm)
-    return running_lcm
+        if pil_int == 0:
+            zero_detection_flag = True
+        else:
+            running_lcm = lcm(pil_int, running_lcm)
+    if zero_detection_flag:
+        return running_lcm, 0
+    else:
+        return running_lcm, running_lcm
 
 
 def B_eps_q(d,eps,q):
 
     split_types = splitting_types(d)
+    B_star = 1
     B = 1
     for split_type in split_types:
-        pil_int = bound_from_split_type(split_type, eps, q)
+        pil_int_star, pil_int = bound_from_split_type(split_type, eps, q)
+        B_star = lcm(B_star,pil_int_star)
         B = lcm(B,pil_int)
-    return B
+    return B_star, B

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -37,6 +37,7 @@ from .type_one_primes import cached_bad_formal_immersion_data
 
 logger = logging.getLogger(__name__)
 
+
 def is_non_increasing(t, part):
 
     for j in range(len(t)-1):
@@ -62,6 +63,7 @@ def get_beta_mats_with_pow(F, pow=1):
 
     return output
 
+
 def remove_duplicates(list_of_e_tuples, part):
 
     output = []
@@ -70,6 +72,7 @@ def remove_duplicates(list_of_e_tuples, part):
         if is_non_increasing(t, part):
             output.append(t)
     return output
+
 
 def splitting_types(d):
     """Implements step 1 of Algorithm 5.1, the possible splitting types

--- a/sage_code/strong_uniform_bounds.py
+++ b/sage_code/strong_uniform_bounds.py
@@ -1,0 +1,99 @@
+"""strong_uniform_bounds.py
+
+    Computes the strong uniform bounds from the second paper.
+
+    ====================================================================
+
+    This file is part of Isogeny Primes.
+
+    Copyright (C) 2023 Barinder S. Banwait and Maarten Derickx
+
+    Isogeny Primes is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    The authors can be reached at: barinder.s.banwait@gmail.com and
+    maarten@mderickx.nl.
+
+    ====================================================================
+
+"""
+
+from sage.all import Partitions, divisors, matrix, GF, lcm
+from itertools import product
+
+from .common_utils import get_weil_polys
+
+def is_non_increasing(t):
+
+    for j in range(len(t)-1):
+        if t[j] < t[j+1]:
+            return False
+    return True
+
+
+def remove_duplicates(list_of_e_tuples):
+
+    output = []
+
+    for t in list_of_e_tuples:
+        if is_non_increasing(t):
+            output.append(t)
+    return output
+
+def splitting_types(d):
+    """Implements step 1 of Algorithm 5.1, the possible splitting types
+
+    Args:
+        d (int): degree of number field
+    """
+
+    types = []
+
+    for r in range(1,d+1):
+        parts = list(Partitions(d, length=r))        
+        for a_part in parts:
+            divisors_of_partition = [divisors(t) for t in a_part]
+            possible_es = list(product(*divisors_of_partition))
+            possible_es = remove_duplicates(possible_es)
+            for possible_e_vec in possible_es:
+                f_vec = [a_part[j]/possible_e_vec[j] for j in range(r)]
+                type_dict = {}
+                type_dict['r'] = r
+                type_dict['es'] = possible_e_vec
+                type_dict['fs'] = tuple(f_vec)
+                types.append(type_dict)
+    return types
+
+
+def strong_mult_bound(d, eps, q):
+    """This implements Algorithm 5.1 from the paper, and returns the integers
+       B_{eps,q} and B^*_{eps,q}.
+
+    Args:
+        d (int): degree of number field
+        eps (tuple): isogeny signature
+        q (int): auxiliary rational prime
+    """
+
+    frob_polys = get_weil_polys(GF(q))
+    frob_poly_mats = [matrix.companion(a_frob_poly) for a_frob_poly in frob_polys]
+    matrix_parent = frob_poly_mats[0].parent()
+    tr_eps = sum(eps)
+    alpha_to_eps_mat = matrix_parent(q**tr_eps)
+    B_eps_q = 1
+    for a_beta_mat in frob_poly_mats:
+        pil_mat = alpha_to_eps_mat.tensor_product(a_beta_mat.parent()(1)) - (
+                  alpha_to_eps_mat.parent()(1)).tensor_product(a_beta_mat)
+        pil_int = pil_mat.det()
+        B_eps_q = lcm(pil_int, B_eps_q)
+    return B_eps_q

--- a/sage_code/type_two_primes.py
+++ b/sage_code/type_two_primes.py
@@ -57,7 +57,19 @@ def LLS(p):
     return (log(p) + 9 + 2.5 * (log(log(p))) ** 2) ** 2
 
 
-def get_type_2_uniform_bound(ecdb_type):
+def compute_S_d(d):
+    return 1
+
+
+def momose_type_2_uniform_bound(d):
+
+    s = compute_S_d(d)
+    F = [f for f in range(1,d+1) if f%2 == 1]
+    v = (4 * log(s) + 10) ** 2
+    T = {p for q in prime_range(ceil(v)+1) for expr in [(q**(2*f) + q**f + 1) for f in F] for p in prime_divisors(expr)}
+    T_CC = [p for p in T if satisfies_condition_CC_uniform(F,p)]
+    P = max(T_CC)
+    return max(P, 4 * (v ** d))
 
     if ecdb_type == "LSS":
         BOUND_TERM = (log(x) + 9 + 2.5 * (log(log(x))) ** 2) ** 2

--- a/sage_code/type_two_primes.py
+++ b/sage_code/type_two_primes.py
@@ -60,33 +60,8 @@ GENERIC_UPPER_BOUND = 10**30
 
 
 def bound_on_largest_root(d, b):
-    """From Maarten's email"""
+    """Largest root of  x-(b log(x))^d"""
     return RR(exp(-d*lambert_w(-1,-1/(d*b))))
-
-
-def compute_S_d(d):
-
-    g = 4 * log(x) + 10
-
-    f_BS = x - (g ** (4*d) + g ** (2*d) + 1)
-
-    largest_root_bound = max(bound_on_largest_root(4*d, 4),bound_on_largest_root(4*d, 5))
-
-    bound_BS = find_root(f_BS, 10, largest_root_bound)
-    
-    lls = (log(x) + 9 + 2.5 * (log(log(x))) ** 2) ** 2
-    try:
-        bound_const = find_root(10**9 - lls, 10**6, largest_root_bound)
-    except RuntimeError:
-        bound_const = largest_root_bound
-
-    f_lls = x - (lls ** (4*d) + lls ** (2*d) + 1)
-    try:
-        bound_LLS = find_root(f_lls, bound_const, largest_root_bound)
-    except RuntimeError:
-        bound_LLS = largest_root_bound
-
-    return ceil(min(bound_BS, max(bound_const, bound_LLS))) 
 
 
 def improved_BS(d, A=4, B=2.5, C=5):
@@ -95,11 +70,33 @@ def improved_BS(d, A=4, B=2.5, C=5):
 
     f_BS = x - (g ** (4*d) + g ** (2*d) + 1)
 
-    largest_root_bound = max(bound_on_largest_root(4*d, 4),bound_on_largest_root(4*d, 5))
+    largest_root_bound = bound_on_largest_root(4*d, A+1)
 
     bound_BS = find_root(f_BS, 10, largest_root_bound)
 
+    assert bound_BS >= RR(exp(2*B+C+1))
+
     return bound_BS, 4*g(x=bound_BS)**(2*d)
+
+
+def compute_S_d(d):
+
+    largest_root_bound = bound_on_largest_root(4*d, 5)
+
+    bound_BS, _ = improved_BS(d)
+
+    lls = (log(x) + 9 + 2.5 * (log(log(x))) ** 2)
+
+    # x > bound_const ensures lls**2 > 10^9
+    bound_const = 10**14000
+
+    f_lls = x - (lls ** (4*d) + lls ** (2*d) + 1)
+    try:
+        bound_LLS = find_root(f_lls, bound_const, largest_root_bound)
+    except RuntimeError:
+        bound_LLS = largest_root_bound
+
+    return ceil(min(bound_BS, max(bound_const, bound_LLS))) 
 
 
 def momose_type_2_uniform_bound(d):

--- a/tests/fast_tests/test_strong_uniform_bounds.py
+++ b/tests/fast_tests/test_strong_uniform_bounds.py
@@ -1,0 +1,58 @@
+"""test_strong_uniform_bounds.py
+
+Test strong uniform bounds.
+
+    ====================================================================
+
+    This file is part of Isogeny Primes.
+
+    Copyright (C) 2023 Barinder S. Banwait and Maarten Derickx
+
+    Isogeny Primes is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    The authors can be reached at: barinder.s.banwait@gmail.com and
+    maarten@mderickx.nl.
+
+    ====================================================================
+
+"""
+
+import pytest
+from sage_code.strong_uniform_bounds import splitting_types
+
+
+test_cases = [
+    (5, [{'r': 1, 'es': (1,), 'fs': (5,)},
+        {'r': 1, 'es': (5,), 'fs': (1,)},
+        {'r': 2, 'es': (1, 1), 'fs': (4, 1)},
+        {'r': 2, 'es': (2, 1), 'fs': (2, 1)},
+        {'r': 2, 'es': (4, 1), 'fs': (1, 1)},
+        {'r': 2, 'es': (1, 1), 'fs': (3, 2)},
+        {'r': 2, 'es': (1, 2), 'fs': (3, 1)},
+        {'r': 2, 'es': (3, 1), 'fs': (1, 2)},
+        {'r': 2, 'es': (3, 2), 'fs': (1, 1)},
+        {'r': 3, 'es': (1, 1, 1), 'fs': (3, 1, 1)},
+        {'r': 3, 'es': (3, 1, 1), 'fs': (1, 1, 1)},
+        {'r': 3, 'es': (1, 1, 1), 'fs': (2, 2, 1)},
+        {'r': 3, 'es': (2, 1, 1), 'fs': (1, 2, 1)},
+        {'r': 3, 'es': (2, 2, 1), 'fs': (1, 1, 1)},
+        {'r': 4, 'es': (1, 1, 1, 1), 'fs': (2, 1, 1, 1)},
+        {'r': 4, 'es': (2, 1, 1, 1), 'fs': (1, 1, 1, 1)},
+        {'r': 5, 'es': (1, 1, 1, 1, 1), 'fs': (1, 1, 1, 1, 1)}])
+]
+
+
+@pytest.mark.parametrize("d, exptd", test_cases)
+def test_get_isogeny_primes(d, exptd):
+    assert splitting_types(d) == exptd

--- a/uniform_isogeny_primes.py
+++ b/uniform_isogeny_primes.py
@@ -1,0 +1,84 @@
+"""isogeny_primes.py
+
+    Return finite list of isogeny primes attached to a number field.
+
+    ====================================================================
+
+    This file is part of Isogeny Primes.
+
+    Copyright (C) 2022 Barinder S. Banwait and Maarten Derickx
+
+    Isogeny Primes is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    The authors can be reached at: barinder.s.banwait@gmail.com and
+    maarten@mderickx.nl.
+
+    ====================================================================
+
+"""
+
+# Imports
+
+import argparse
+import logging
+
+from sage.all import Integer, prime_divisors
+
+from sage_code.strong_uniform_bounds import tr_not_6_unif_bd, type_one_unif_primes
+
+
+def do_uniform(d, eps):
+    tr_not_6_bd = Integer(tr_not_6_unif_bd(d, eps))
+    logging.info(f"Trace not 6 mod 12 bound is {tr_not_6_bd}")
+    # logging.info(f"Trace not 6 mod 12 primes are {tr_not_6_bd.prime_divisors()}")
+
+    type_one_bound = type_one_unif_primes(d)
+
+    logging.info(f"Type 1 uniform bound is {type_one_bound}")
+
+def get_eps_from_input(tuple_as_str):
+    return tuple([Integer(t) for t in tuple_as_str.split(",")])
+
+
+def cli_handler(args):  # pylint: disable=redefined-outer-name
+
+    loglevel = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+        level=loglevel,
+    )
+    logging.debug("Debugging level for log messages set.")
+
+    eps = get_eps_from_input(args.eps)
+    do_uniform(args.d, eps)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "d",
+        metavar="d",
+        type=int,
+        help="bound on the primes to try the method of the appendix",
+    )
+    parser.add_argument(
+        "--eps",
+        required=True,
+        type=str,
+        help="bound on the primes to try the method of the appendix",
+    )
+    parser.add_argument("--verbose", action="store_true", help="get more info printed")
+    args = parser.parse_args()
+    cli_handler(args)

--- a/uniform_isogeny_primes.py
+++ b/uniform_isogeny_primes.py
@@ -40,7 +40,7 @@ from sage_code.strong_uniform_bounds import unif_bd, type_one_unif_primes
 
 def do_uniform_quadratic():
 
-    EPSILONS = [(0,4), (0,6), (0,8), (4,4), (4,6), (4,12)]
+    EPSILONS = [(0,4), (0,8), (4,4), (4,6), (4,12)]
 
     for eps in EPSILONS:
         bd = Integer(unif_bd(2,eps))

--- a/uniform_isogeny_primes.py
+++ b/uniform_isogeny_primes.py
@@ -60,6 +60,7 @@ def do_uniform(d, eps):
 
     logging.info(f"Type 1 uniform bound is {type_one_bound}")
 
+
 def get_eps_from_input(tuple_as_str):
     return tuple([Integer(t) for t in tuple_as_str.split(",")])
 

--- a/uniform_isogeny_primes.py
+++ b/uniform_isogeny_primes.py
@@ -35,11 +35,24 @@ import logging
 
 from sage.all import Integer, prime_divisors
 
-from sage_code.strong_uniform_bounds import tr_not_6_unif_bd, type_one_unif_primes
+from sage_code.strong_uniform_bounds import unif_bd, type_one_unif_primes
+
+
+def do_uniform_quadratic():
+
+    EPSILONS = [(0,4), (0,6), (0,8), (4,4), (4,6), (4,12)]
+
+    for eps in EPSILONS:
+        bd = Integer(unif_bd(2,eps))
+        logging.info(f"Isogeny primes for {eps} are {bd.prime_divisors()}")
+
+    type_one_bound = type_one_unif_primes(int(2))
+
+    logging.info(f"Type 1 uniform bound is {type_one_bound}")
 
 
 def do_uniform(d, eps):
-    tr_not_6_bd = Integer(tr_not_6_unif_bd(d, eps))
+    tr_not_6_bd = Integer(unif_bd(d, eps))
     logging.info(f"Trace not 6 mod 12 bound is {tr_not_6_bd}")
     # logging.info(f"Trace not 6 mod 12 primes are {tr_not_6_bd.prime_divisors()}")
 
@@ -62,7 +75,12 @@ def cli_handler(args):  # pylint: disable=redefined-outer-name
     logging.debug("Debugging level for log messages set.")
 
     eps = get_eps_from_input(args.eps)
-    do_uniform(args.d, eps)
+
+    if args.d == int(2):
+        do_uniform_quadratic()
+    else:
+        do_uniform(args.d, eps)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi @koffie could you review this draft PR to check that the implementation for #97 is going in the right direction? This is still WIP, at the moment I think it's computing the product of the B_{eps,q,beta} ints shown in step 2 of Algorithm 5.1 of our paper, and outputs both B^\ast and B. I haven't added in \pm1, \pm q yet into the definition of the S sets, that shouldn't be hard...

This is using your idea from `pil_integers.py` of not extracting beta roots, instead using companion matrices, and taking tensor products; this gives larger integers than necessary, but is much faster.